### PR TITLE
fix: resolve linter formating issues triggered in PR #9 checks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 // src/main.rs
 
 use clap::{Parser, Subcommand};
-use hubstry_iso_code::{models::EngineConfig, semantic_engine::SemanticEngine, scanner};
+use hubstry_iso_code::{models::EngineConfig, scanner, semantic_engine::SemanticEngine};
 use std::fs;
 use std::path::PathBuf;
 
@@ -54,7 +54,15 @@ enum Commands {
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Commands::Analyze { file, dir: _, lang: _, rules: _, format: _, output: _, threshold } => {
+        Commands::Analyze {
+            file,
+            dir: _,
+            lang: _,
+            rules: _,
+            format: _,
+            output: _,
+            threshold,
+        } => {
             let file_path = file.unwrap_or_else(|| "src/main.rs".to_string());
             let path = PathBuf::from(file_path);
 
@@ -83,25 +91,30 @@ async fn main() -> anyhow::Result<()> {
                 std::process::exit(1);
             }
         }
-        Commands::Scan { url, rules: _, format: _, output: _ } => {
+        Commands::Scan {
+            url,
+            rules: _,
+            format: _,
+            output: _,
+        } => {
             println!("Iniciando Web Scan para URL: {}", url);
             let html = if url.starts_with("http") {
-                 let client = reqwest::Client::builder()
-                     .timeout(std::time::Duration::from_secs(30))
-                     .build()?;
-                 let res = client.get(&url).send().await?;
-                 res.text().await?
+                let client = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()?;
+                let res = client.get(&url).send().await?;
+                res.text().await?
             } else {
-                 fs::read_to_string(&url)?
+                fs::read_to_string(&url)?
             };
 
             use scanner::WebScanner;
             let dom_scanner = scanner::StaticDomScanner::new();
             let config = scanner::ScanConfig {
-                 max_pages: 1,
-                 follow_links: false,
-                 check_subpages: vec![],
-                 rules_path: "".to_string(),
+                max_pages: 1,
+                follow_links: false,
+                check_subpages: vec![],
+                rules_path: "".to_string(),
             };
 
             println!("Html length: {} bytes", html.len());
@@ -112,24 +125,27 @@ async fn main() -> anyhow::Result<()> {
             println!("Detailed scanner analysis complete.");
         }
         Commands::QuickScan { url } => {
-             println!("Iniciando Quick Scan para URL: {}", url);
+            println!("Iniciando Quick Scan para URL: {}", url);
 
-             let res = if url.starts_with("http") {
-                 scanner::quick_scan(&url).await?
-             } else {
-                 let html = fs::read_to_string(&url)?;
-                 let age_gate_result = scanner::age_gate_detector::detect_age_gate(&html);
+            let res = if url.starts_with("http") {
+                scanner::quick_scan(&url).await?
+            } else {
+                let html = fs::read_to_string(&url)?;
+                let age_gate_result = scanner::age_gate_detector::detect_age_gate(&html);
 
-                 let has_age_verification = age_gate_result.method != scanner::age_gate_detector::AgeVerificationMethod::None;
-                 let verification_method = format!("{:?}", age_gate_result.method);
+                let has_age_verification = age_gate_result.method
+                    != scanner::age_gate_detector::AgeVerificationMethod::None;
+                let verification_method = format!("{:?}", age_gate_result.method);
 
-                 let risk_level = match age_gate_result.method {
-                     scanner::age_gate_detector::AgeVerificationMethod::SelfDeclarationOnly => "CRITICAL",
-                     scanner::age_gate_detector::AgeVerificationMethod::None => "CRITICAL",
-                     _ => "OK",
-                 };
+                let risk_level = match age_gate_result.method {
+                    scanner::age_gate_detector::AgeVerificationMethod::SelfDeclarationOnly => {
+                        "CRITICAL"
+                    }
+                    scanner::age_gate_detector::AgeVerificationMethod::None => "CRITICAL",
+                    _ => "OK",
+                };
 
-                 let (summary, recommendation) = match age_gate_result.method {
+                let (summary, recommendation) = match age_gate_result.method {
                      scanner::age_gate_detector::AgeVerificationMethod::SelfDeclarationOnly => (
                          "Detectada autodeclaração de idade na página.".to_string(),
                          "A autodeclaração é proibida pelo ECA Digital. Substitua por verificação oficial via API (Serpro/Gov.br).".to_string()
@@ -143,17 +159,17 @@ async fn main() -> anyhow::Result<()> {
                          "A verificação está em conformidade. Continue garantindo a proteção aos menores.".to_string()
                      ),
                  };
-                 scanner::QuickScanResult {
-                     url,
-                     has_age_verification,
-                     verification_method,
-                     risk_level: risk_level.to_string(),
-                     summary,
-                     recommendation,
-                 }
-             };
-             println!("Resumo da Avaliação Rápida:");
-             println!("{}", serde_json::to_string_pretty(&res)?);
+                scanner::QuickScanResult {
+                    url,
+                    has_age_verification,
+                    verification_method,
+                    risk_level: risk_level.to_string(),
+                    summary,
+                    recommendation,
+                }
+            };
+            println!("Resumo da Avaliação Rápida:");
+            println!("{}", serde_json::to_string_pretty(&res)?);
         }
     }
 

--- a/src/scanner/age_gate_detector.rs
+++ b/src/scanner/age_gate_detector.rs
@@ -25,7 +25,10 @@ pub fn detect_age_gate(html: &str) -> AgeGateResult {
     for el in document.select(&checkbox_selector) {
         if let Some(name) = el.value().attr("name") {
             let name_lower = name.to_lowercase();
-            if name_lower.contains("age") || name_lower.contains("idade") || name_lower.contains("18") {
+            if name_lower.contains("age")
+                || name_lower.contains("idade")
+                || name_lower.contains("18")
+            {
                 method = AgeVerificationMethod::SelfDeclarationOnly;
                 elements_found.push(format!("Checkbox autodeclaração: {:?}", name));
             }
@@ -47,7 +50,10 @@ pub fn detect_age_gate(html: &str) -> AgeGateResult {
     for el in document.select(&button_selector) {
         let text_content: String = el.text().collect::<Vec<_>>().join(" ");
         let text_lower = text_content.to_lowercase();
-        if text_lower.contains("tenho 18") || text_lower.contains("sou maior") || text_lower.contains("i am 18+") {
+        if text_lower.contains("tenho 18")
+            || text_lower.contains("sou maior")
+            || text_lower.contains("i am 18+")
+        {
             method = AgeVerificationMethod::SelfDeclarationOnly;
             elements_found.push(format!("Botão autodeclaração: {:?}", text_content.trim()));
         }
@@ -58,10 +64,15 @@ pub fn detect_age_gate(html: &str) -> AgeGateResult {
     for el in document.select(&script_selector) {
         if let Some(src) = el.value().attr("src") {
             let src_lower = src.to_lowercase();
-            if src_lower.contains("gov.br") || src_lower.contains("serpro") || src_lower.contains("datavalid") {
+            if src_lower.contains("gov.br")
+                || src_lower.contains("serpro")
+                || src_lower.contains("datavalid")
+            {
                 method = AgeVerificationMethod::GovernmentApi;
                 elements_found.push(format!("API Governamental: {:?}", src));
-            } else if src_lower.contains("accounts.google.com") || src_lower.contains("identity.googleapis") {
+            } else if src_lower.contains("accounts.google.com")
+                || src_lower.contains("identity.googleapis")
+            {
                 method = AgeVerificationMethod::GoogleZkp;
                 elements_found.push(format!("API Google ZKP: {:?}", src));
             }

--- a/src/scanner/dark_pattern_detector.rs
+++ b/src/scanner/dark_pattern_detector.rs
@@ -31,7 +31,10 @@ pub fn detect_dark_patterns(html: &str) -> DarkPatternResult {
             name_lower.contains("infinite-scroll") || name_lower.contains("endless-feed")
         });
 
-        if classes_lower.contains("infinite-scroll") || classes_lower.contains("endless-feed") || has_infinite_scroll_attr {
+        if classes_lower.contains("infinite-scroll")
+            || classes_lower.contains("endless-feed")
+            || has_infinite_scroll_attr
+        {
             has_dark_patterns = true;
             elements_found.push("Rolagem Infinita (Infinite Scroll) detectada".to_string());
         }

--- a/src/scanner/lootbox_detector.rs
+++ b/src/scanner/lootbox_detector.rs
@@ -15,7 +15,13 @@ pub fn detect_lootbox(html: &str) -> LootboxResult {
     for el in document.select(&script_selector) {
         let script_content = el.text().collect::<Vec<_>>().join(" ").to_lowercase();
 
-        let target_terms = ["lootbox", "loot_box", "gacha", "mystery_box", "random_reward"];
+        let target_terms = [
+            "lootbox",
+            "loot_box",
+            "gacha",
+            "mystery_box",
+            "random_reward",
+        ];
         for term in target_terms {
             if script_content.contains(term) {
                 has_lootbox = true;

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
+pub mod ad_tracker_detector;
 pub mod age_gate_detector;
 pub mod dark_pattern_detector;
-pub mod ad_tracker_detector;
-pub mod privacy_policy_checker;
 pub mod lootbox_detector;
+pub mod privacy_policy_checker;
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct WebScanResult {
@@ -62,7 +62,8 @@ pub async fn quick_scan(url: &str) -> Result<QuickScanResult> {
 
     let age_gate_result = age_gate_detector::detect_age_gate(&html);
 
-    let has_age_verification = age_gate_result.method != age_gate_detector::AgeVerificationMethod::None;
+    let has_age_verification =
+        age_gate_result.method != age_gate_detector::AgeVerificationMethod::None;
 
     let verification_method = format!("{:?}", age_gate_result.method);
 
@@ -128,7 +129,7 @@ impl WebScanner for StaticDomScanner {
         // 1. Age Gate Detect
         let age_gate_result = age_gate_detector::detect_age_gate(&html);
         if age_gate_result.method == age_gate_detector::AgeVerificationMethod::SelfDeclarationOnly {
-             violations.push(WebViolation {
+            violations.push(WebViolation {
                   rule_id: "ECA.AGE.SELF_DECLARATION_BAN".to_string(),
                   severity: "CRITICAL".to_string(),
                   business_description: "Autodeclaração de idade localizada na página.".to_string(),
@@ -139,9 +140,9 @@ impl WebScanner for StaticDomScanner {
                   remediation_business: "Remova a autodeclaração de idade.".to_string(),
                   remediation_technical: "Substitua checkboxes/inputs simples por integrações em backend usando as APIs oficiais como o Serpro DataValid.".to_string(),
              });
-             score -= 20.0;
+            score -= 20.0;
         } else if age_gate_result.method == age_gate_detector::AgeVerificationMethod::None {
-             violations.push(WebViolation {
+            violations.push(WebViolation {
                   rule_id: "ECA.AGE.VERIFY".to_string(),
                   severity: "CRITICAL".to_string(),
                   business_description: "Nenhum sistema de verificação de idade foi encontrado para a plataforma.".to_string(),
@@ -152,13 +153,13 @@ impl WebScanner for StaticDomScanner {
                   remediation_business: "Adicione verificação de idade segura ao fluxo inicial da aplicação.".to_string(),
                   remediation_technical: "Crie um interceptador de requisições de página para realizar o Age-Gate com chamadas de integridade backend.".to_string(),
              });
-             score -= 20.0;
+            score -= 20.0;
         }
 
         // 2. Dark Patterns
         let dark_patterns_result = dark_pattern_detector::detect_dark_patterns(&html);
         if dark_patterns_result.has_dark_patterns {
-             violations.push(WebViolation {
+            violations.push(WebViolation {
                   rule_id: "ECA.DESIGN.DARK_PATTERNS".to_string(),
                   severity: "HIGH".to_string(),
                   business_description: "Padrão de design para engajamento e hiperuso contínuo detectado.".to_string(),
@@ -169,13 +170,13 @@ impl WebScanner for StaticDomScanner {
                   remediation_business: "Desative autoplay de mídias e scrolls infinitos.".to_string(),
                   remediation_technical: "Remova a tag 'autoplay' do video e substitua 'infinite-scroll' por paginação controlada.".to_string(),
              });
-             score -= 10.0;
+            score -= 10.0;
         }
 
         // 3. Ad Trackers
         let trackers_result = ad_tracker_detector::detect_ad_trackers(&html);
         if trackers_result.has_trackers {
-             violations.push(WebViolation {
+            violations.push(WebViolation {
                   rule_id: "ECA.DATA.RETENTION_BAN".to_string(),
                   severity: "HIGH".to_string(),
                   business_description: "Scripts de rastreamento de anúncios (Trackers/Analytics) estão injetados na página desprotegida.".to_string(),
@@ -186,13 +187,13 @@ impl WebScanner for StaticDomScanner {
                   remediation_business: "Solicite gerenciamento de consentimento ou remova o tracking por padrão para perfis de risco (menores de 18).".to_string(),
                   remediation_technical: "Envolva os scripts identificados com regras de validação para injetá-los apenas após aprovação explícita e verificação de idade do visitante.".to_string(),
              });
-             score -= 15.0;
+            score -= 15.0;
         }
 
         // 4. Privacy Policy
         let privacy_result = privacy_policy_checker::check_privacy_policy(&html);
         if !privacy_result.has_policy_link {
-             violations.push(WebViolation {
+            violations.push(WebViolation {
                   rule_id: "ECA.PRIVACY.MAX_DEFAULT".to_string(),
                   severity: "HIGH".to_string(),
                   business_description: "O portal parece não conter um link de acesso ou referência explícita a uma política de privacidade.".to_string(),
@@ -203,13 +204,13 @@ impl WebScanner for StaticDomScanner {
                   remediation_business: "Inclua a política detalhando LGPD e adequações para menores de idade de modo vísivel no rodapé/header.".to_string(),
                   remediation_technical: "Adicione <a href='/politica-de-privacidade'>Política de Privacidade</a> globalmente no DOM e atualize os menús.".to_string(),
              });
-             score -= 10.0;
+            score -= 10.0;
         }
 
         // 5. Lootboxes
         let lootbox_result = lootbox_detector::detect_lootbox(&html);
         if lootbox_result.has_lootbox {
-             violations.push(WebViolation {
+            violations.push(WebViolation {
                   rule_id: "ECA.DESIGN.LOOTBOX_BAN".to_string(),
                   severity: "CRITICAL".to_string(),
                   business_description: "Termos ligados à mecânica gacha/lootboxes identificados nas rotinas sem restrições explícitas acionadas.".to_string(),
@@ -220,7 +221,7 @@ impl WebScanner for StaticDomScanner {
                   remediation_business: "A compra ou acesso sem controle a lootboxes é proibida para menores. Requer Gate Bloqueante imediato.".to_string(),
                   remediation_technical: "Restringir execução dessa mecânica. Implementar `verify_age_wall` e certificar-se da validade do token de acesso do usuário de forma rigorosa.".to_string(),
              });
-             score -= 25.0;
+            score -= 25.0;
         }
 
         Ok(WebScanResult {

--- a/src/scanner/privacy_policy_checker.rs
+++ b/src/scanner/privacy_policy_checker.rs
@@ -26,7 +26,12 @@ pub fn check_privacy_policy(html: &str) -> PrivacyPolicyResult {
 
     // Simplificação para MVP: Buscar menções diretas na página atual (ou no footer)
     // Para análise profunda, idealmente faríamos um fetch() na URL da política encontrada.
-    let body_text = document.root_element().text().collect::<Vec<_>>().join(" ").to_lowercase();
+    let body_text = document
+        .root_element()
+        .text()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase();
     if body_text.contains("menores")
         || body_text.contains("crianças")
         || body_text.contains("lgpd")

--- a/tests/test_web_scanner.rs
+++ b/tests/test_web_scanner.rs
@@ -1,13 +1,20 @@
 #[cfg(test)]
 mod tests {
-    use hubstry_iso_code::scanner::{age_gate_detector, dark_pattern_detector, ad_tracker_detector, privacy_policy_checker, lootbox_detector};
+    use hubstry_iso_code::scanner::{
+        ad_tracker_detector, age_gate_detector, dark_pattern_detector, lootbox_detector,
+        privacy_policy_checker,
+    };
 
     #[test]
     fn test_non_compliant_site() {
-        let html = std::fs::read_to_string("examples/web/non_compliant_site.html").expect("Failed to read example");
+        let html = std::fs::read_to_string("examples/web/non_compliant_site.html")
+            .expect("Failed to read example");
 
         let age_gate_result = age_gate_detector::detect_age_gate(&html);
-        assert_eq!(age_gate_result.method, age_gate_detector::AgeVerificationMethod::SelfDeclarationOnly);
+        assert_eq!(
+            age_gate_result.method,
+            age_gate_detector::AgeVerificationMethod::SelfDeclarationOnly
+        );
         assert!(!age_gate_result.elements_found.is_empty());
 
         let dark_patterns_result = dark_pattern_detector::detect_dark_patterns(&html);
@@ -25,10 +32,14 @@ mod tests {
 
     #[test]
     fn test_compliant_site() {
-        let html = std::fs::read_to_string("examples/web/compliant_site.html").expect("Failed to read example");
+        let html = std::fs::read_to_string("examples/web/compliant_site.html")
+            .expect("Failed to read example");
 
         let age_gate_result = age_gate_detector::detect_age_gate(&html);
-        assert_eq!(age_gate_result.method, age_gate_detector::AgeVerificationMethod::GovernmentApi);
+        assert_eq!(
+            age_gate_result.method,
+            age_gate_detector::AgeVerificationMethod::GovernmentApi
+        );
 
         let dark_patterns_result = dark_pattern_detector::detect_dark_patterns(&html);
         assert!(!dark_patterns_result.has_dark_patterns);


### PR DESCRIPTION
- Correctly structured `cargo fmt` suggestions missing out from local sync that broke strict action runs.
- Resolved trailing spaces and nested logic formatting within core web scanner detectors.